### PR TITLE
feat(redis): add support for execute redis commands at case destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,39 @@ The `member_id` field is got from test case response data, as the example below:
 }
 ```
 
+#### Redis Support
+
+##### Basic usage
+
+**Redis** commands is supported now, the redis is configured in the `config.json` file specified in command
+
+```
+{
+  "redis": {
+    "url": "redis://127.0.0.1:6379/1"
+  }
+}
+```
+
+You just need to define the commands for redis after the test:
+
+```
+{
+  "body": {
+    "name": "testuser",
+    "avatar": "http://static.image.com/test.png"
+  },
+  "destroy": {
+    "redis": {
+      "commands": [
+        ["inc", "visit_total"],
+        ["set", "set_key", "value"]
+      ]
+    }
+  }
+}
+```
+
 #### Basic load test
 
 If you specify the `loadtest` field in the case definition, you can make basic load test. The `loadtest` field is an options object, you can find related options [here](https://github.com/alexfernandez/loadtest#options). See example below:

--- a/lib/redis-client.coffee
+++ b/lib/redis-client.coffee
@@ -1,0 +1,25 @@
+redis = require 'redis'
+_ = require 'underscore'
+
+class RedisClient
+    constructor: (url) ->
+        @url = url
+        @client = redis.createClient @url
+
+    exec: (commands) =>
+        client = @client
+        @client.multi @formatCommands commands
+               .exec (err, replies) ->
+                    if err?
+                        console.log err
+                    client.quit()
+
+    formatCommands: (commands) =>
+        if commands? and _.isArray commands
+            if commands[..]? and  not _.isArray commands[0]
+                commands = [commands]
+        else
+            commands = []
+        commands
+
+module.exports = RedisClient

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "request": "^2.53.0",
     "source-map-support": "^0.3.2",
     "tv4": "^1.2.7",
-    "underscore": "^1.8.2"
+    "underscore": "^1.8.2",
+    "redis": "^2.5.3"
   }
 }


### PR DESCRIPTION

## Support redis commands:

For example:

Add configuration in config.json:

```
"redis": {
    "url": "redis://127.0.0.1/1"
  }
```

Add depends in case file:

```
"destroy": {
   ...
    "redis": {
      "commands": [
       ["set", "command1", 1],
       ["del", "command1"]
      ]
    }
  },
```

After suite, it will execute redis commands:
1. `set command1 1`
2. `del command1`